### PR TITLE
151-bug-share-button-insufficient-permission-on-ios

### DIFF
--- a/src/components/ui/ShareButton.tsx
+++ b/src/components/ui/ShareButton.tsx
@@ -64,7 +64,7 @@ const ShareButton = () => {
     if (stats) {
       message += `\n${stats.currentStreak}🔥`;
     }
-    await navigator.clipboard.writeText(message);
+    navigator.clipboard.writeText(message);
     toast.dismiss();
     toast.custom(() => <p className={styles.toast}>Copied to clipboard</p>);
   };


### PR DESCRIPTION
## Description
Removed await keyboard before navigator.clipboard.writeText() call in ShareButton onClick handler.

Fixes #151

## Type of change
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

